### PR TITLE
identify user on server side

### DIFF
--- a/api/modd.conf
+++ b/api/modd.conf
@@ -1,4 +1,4 @@
-**/*.go, web/* {
+*.go, **/*.go, web/* {
     prep: go build -v -o ./bin/server .
     daemon: ./bin/server
 }

--- a/ui/src/components/Home.js
+++ b/ui/src/components/Home.js
@@ -6,6 +6,7 @@ import Footer from "./Footer";
 //import FeaturedProducts from "./components/Featured";
 import School from "./School";
 import Introduce from "./Introduce";
+import MyDonations from "./MyDonations";
 
 function Home() {
 
@@ -14,7 +15,8 @@ function Home() {
             {/* <Header/> */}
             <Introduce/>
             <School/>
-            {/* <FeaturedProducts/> */} 
+            {/* <FeaturedProducts/> */}
+            <MyDonations/>
         </div>
     );
 }

--- a/ui/src/components/MyDonations.js
+++ b/ui/src/components/MyDonations.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import {useAuth0} from "@auth0/auth0-react";
+import {Col, Container, Row } from "react-bootstrap";
+import useProtectedApi from "../hooks/api"
+
+function DonationsList({className = ''} = {}) {
+  const {isAuthenticated} = useAuth0();
+  const { loading, error, donations } = useProtectedApi('/api/my-donations');
+
+  if (!isAuthenticated) return <div>Please log in to see your donations</div>
+
+  if (loading) return <div>Loading donations...</div>
+  if (error) return <div>Failed to load donations: {error.message}</div>
+  if (donations.length === 0) return <div>No donations yet</div>
+
+  return <code>{JSON.stringify(donations)}</code>
+}
+
+function MyDonations() {
+  return (
+      <section className={"ftco-section"}>
+          <Container>
+              <Row>
+                  <Col>
+                    <h2>Your donations</h2>
+                    <DonationsList/>
+                  </Col>
+              </Row>
+          </Container>
+      </section>)
+}
+
+export default MyDonations

--- a/ui/src/components/Profile.js
+++ b/ui/src/components/Profile.js
@@ -1,15 +1,10 @@
+import React from 'react'
 import {useAuth0} from "@auth0/auth0-react";
-import useApi from "../hooks/api"
 
 function Profile({className = ''} = {}) {
   const {user, isAuthenticated} = useAuth0();
-  const { loading, error, data } = useApi('/secret');
-  
-  if (!isAuthenticated) return <div>Not logged in</div>
-  if (loading) return <div>Loading scret...</div>
-  if (error) return <div>Error: {error.message}</div>
-
-  return <div className={className}>Hi {user.name}, the secrte is {data.secret}</div>
+  if (!isAuthenticated) return null
+  return <div className={className}>Hi {user.name}</div>
 }
 
 export default Profile

--- a/ui/src/hooks/api.js
+++ b/ui/src/hooks/api.js
@@ -10,7 +10,7 @@ console.log('baseURL', baseURL, 'audience', defaultAudience)
 
 // see https://github.com/auth0/auth0-react/blob/master/EXAMPLES.md
 
-const useApi = (path, options = {}) => {
+const useProtectedApi = (path, options = {}) => {
   const { getAccessTokenSilently } = useAuth0();
   const [state, setState] = useState({
     error: null,
@@ -36,7 +36,7 @@ const useApi = (path, options = {}) => {
         });
         setState({
           ...state,
-          data: await res.json(),
+          donations: await res.json(),
           error: null,
           loading: false,
         });
@@ -56,4 +56,4 @@ const useApi = (path, options = {}) => {
   };
 };
 
-export default useApi
+export default useProtectedApi


### PR DESCRIPTION
@venkata6 check this out, nothing new. I just lined up what I had in the previous commit

This is token-based auth! So no sessions. Maybe you had the opposite in mind, it all depends on the UI and navigations the site suppose to have. You can still identify the user but only in API requests supplying the token, see what `/api/my-donations` handler does

JS app is requesting the token from Auth0 using `ClientID` defined in "Auth0 / Applications / helpschool-dev" app. I just realized that It was failing for you because of missing credentials. Create `ui/.env` with following

```
BROWSER=none
REACT_APP_AUTH0_DOMAIN=helpschool.us.auth0.com
REACT_APP_AUTH0_CLIENT_ID=pf6H9BNexezeHm2Yj7VECSRU4ETzC68w
REACT_APP_API_URL=http://localhost:8080
REACT_APP_API_AUDIENCE=https://helpschool/api
REACT_APP_API_SCOPE=read:current_user
```

There is also an API entity defined in "Auth0 / Applications / APIs / Site API" allowing the client app above to acquire JWTs by querying `https://helpschool.us.auth0.com/`. We include user email into the token using Auth0 Rule, see "Auth0 / Auth pipeline / Rules"

The site should (🤞) run fine locally on both `:8080` (embedded assets) and `:3000` (dynamically compiled assets) ports